### PR TITLE
feat: add flag to enable turnitin submission

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -214,7 +214,25 @@ Instructors endpoints
 Configuring required in the Open edX platform
 *********************************************
 
-You need to configure the following settings to use the plugin:
+By default the turnitin functionality is disabled. If you want to enable the
+functionality globally (in all courses) add the following setting in your LMS:
+
+.. code-block:: python
+
+  ENABLE_TURNITIN_SUBMISSION = True
+
+Optionally, you can enable the functionality in a specific course by adding the
+following setting from **Studio** > **Advanced Settings** > **Other Course
+Settings**:
+
+.. code-block:: json
+
+  {
+    "ENABLE_TURNITIN_SUBMISSION": true
+  }
+
+Finally, to use the turnitin API it is necessary to configure the following
+settings in your LMS:
 
 .. code-block:: python
 

--- a/platform_plugin_turnitin/edxapp_wrapper/backends/modulestore_q_v1.py
+++ b/platform_plugin_turnitin/edxapp_wrapper/backends/modulestore_q_v1.py
@@ -1,0 +1,6 @@
+"""
+Modulestore definitions for Open edX Quince release.
+"""
+
+# pylint: disable=import-error, unused-import
+from xmodule.modulestore.django import modulestore

--- a/platform_plugin_turnitin/edxapp_wrapper/backends/modulestore_q_v1_test.py
+++ b/platform_plugin_turnitin/edxapp_wrapper/backends/modulestore_q_v1_test.py
@@ -1,0 +1,5 @@
+"""
+Modulestore tests definitions for Open edX Quince release.
+"""
+
+modulestore = object

--- a/platform_plugin_turnitin/edxapp_wrapper/modulestore.py
+++ b/platform_plugin_turnitin/edxapp_wrapper/modulestore.py
@@ -1,0 +1,17 @@
+"""
+Modulestore generalized definitions.
+"""
+
+from importlib import import_module
+
+from django.conf import settings
+
+
+def modulestore(*args, **kwargs):
+    """
+    Wrapper for `xmodule.modulestore.django.modulestore`
+    """
+    backend_function = settings.PLATFORM_PLUGIN_TURNITIN_MODULESTORE_BACKEND
+    backend = import_module(backend_function)
+
+    return backend.modulestore(*args, **kwargs)

--- a/platform_plugin_turnitin/extensions/filters.py
+++ b/platform_plugin_turnitin/extensions/filters.py
@@ -1,14 +1,17 @@
 """Filters for the Turnitin plugin."""
 
+from crum import get_current_request
+from django.conf import settings
+from opaque_keys.edx.keys import CourseKey
 from openedx_filters import PipelineStep
+
+from platform_plugin_turnitin.edxapp_wrapper.modulestore import modulestore
 
 
 class ORASubmissionViewTurnitinWarning(PipelineStep):
     """Add warning message about Turnitin to the ORA submission view."""
 
-    def run_filter(  # pylint: disable=unused-argument, disable=arguments-differ
-        self, context: dict, template_name: str
-    ) -> dict:
+    def run_filter(self, context: dict, template_name: str) -> dict:  # pylint: disable=arguments-differ
         """
         Execute filter that loads the submission template with a warning message that
         notifies the user that the submission will be sent to Turnitin.
@@ -20,7 +23,24 @@ class ORASubmissionViewTurnitinWarning(PipelineStep):
         Returns:
             dict: The context dictionary and the template name.
         """
+        if settings.ENABLE_TURNITIN_SUBMISSION:
+            return {
+                "context": context,
+                "template_name": "turnitin/oa_response.html",
+            }
+
+        course_id = get_current_request().resolver_match.kwargs.get("course_id")
+        course_key = CourseKey.from_string(course_id)
+        course_block = modulestore().get_course(course_key)
+        enable_in_course = course_block.other_course_settings.get("ENABLE_TURNITIN_SUBMISSION", False)
+
+        if enable_in_course:
+            return {
+                "context": context,
+                "template_name": "turnitin/oa_response.html",
+            }
+
         return {
             "context": context,
-            "template_name": "turnitin/oa_response.html",
+            "template_name": template_name,
         }

--- a/platform_plugin_turnitin/extensions/filters.py
+++ b/platform_plugin_turnitin/extensions/filters.py
@@ -1,8 +1,7 @@
 """Filters for the Turnitin plugin."""
 
-from crum import get_current_request
 from django.conf import settings
-from opaque_keys.edx.keys import CourseKey
+from opaque_keys.edx.keys import UsageKey
 from openedx_filters import PipelineStep
 
 from platform_plugin_turnitin.edxapp_wrapper.modulestore import modulestore
@@ -29,8 +28,7 @@ class ORASubmissionViewTurnitinWarning(PipelineStep):
                 "template_name": "turnitin/oa_response.html",
             }
 
-        course_id = get_current_request().resolver_match.kwargs.get("course_id")
-        course_key = CourseKey.from_string(course_id)
+        course_key = UsageKey.from_string(context["xblock_id"]).course_key
         course_block = modulestore().get_course(course_key)
         enable_in_course = course_block.other_course_settings.get("ENABLE_TURNITIN_SUBMISSION", False)
 

--- a/platform_plugin_turnitin/handlers.py
+++ b/platform_plugin_turnitin/handlers.py
@@ -7,7 +7,7 @@ from platform_plugin_turnitin.edxapp_wrapper.modulestore import modulestore
 from platform_plugin_turnitin.tasks import ora_submission_created_task
 
 
-def ora_submission_created(submission, **kwargs):  # pylint: disable=unused-argument
+def ora_submission_created(submission, **kwargs):
     """
     Handle the ORA_SUBMISSION_CREATED event.
 
@@ -26,7 +26,13 @@ def ora_submission_created(submission, **kwargs):  # pylint: disable=unused-argu
         call_ora_submission_created_task(submission)
 
 
-def call_ora_submission_created_task(submission):
+def call_ora_submission_created_task(submission) -> None:
+    """
+    Call the ORA submission created task.
+
+    Args:
+        submission (ORASubmissionData): The ORA submission data.
+    """
     ora_submission_created_task.delay(
         submission.uuid,
         submission.anonymous_user_id,

--- a/platform_plugin_turnitin/handlers.py
+++ b/platform_plugin_turnitin/handlers.py
@@ -1,8 +1,7 @@
 """Event handlers for the Turnitin plugin."""
 
-from crum import get_current_request
 from django.conf import settings
-from opaque_keys.edx.keys import CourseKey
+from opaque_keys.edx.keys import UsageKey
 
 from platform_plugin_turnitin.edxapp_wrapper.modulestore import modulestore
 from platform_plugin_turnitin.tasks import ora_submission_created_task
@@ -19,8 +18,7 @@ def ora_submission_created(submission, **kwargs):  # pylint: disable=unused-argu
         call_ora_submission_created_task(submission)
         return
 
-    course_id = get_current_request().resolver_match.kwargs.get("course_id")
-    course_key = CourseKey.from_string(course_id)
+    course_key = UsageKey.from_string(submission.location).course_key
     course_block = modulestore().get_course(course_key)
     enable_in_course = course_block.other_course_settings.get("ENABLE_TURNITIN_SUBMISSION", False)
 

--- a/platform_plugin_turnitin/handlers.py
+++ b/platform_plugin_turnitin/handlers.py
@@ -1,15 +1,34 @@
 """Event handlers for the Turnitin plugin."""
 
+from crum import get_current_request
+from django.conf import settings
+from opaque_keys.edx.keys import CourseKey
+
+from platform_plugin_turnitin.edxapp_wrapper.modulestore import modulestore
 from platform_plugin_turnitin.tasks import ora_submission_created_task
 
 
-def ora_submission_created(submission, **kwargs):
+def ora_submission_created(submission, **kwargs):  # pylint: disable=unused-argument
     """
     Handle the ORA_SUBMISSION_CREATED event.
 
     Args:
         submission (ORASubmissionData): The ORA submission data.
     """
+    if settings.ENABLE_TURNITIN_SUBMISSION:
+        call_ora_submission_created_task(submission)
+        return
+
+    course_id = get_current_request().resolver_match.kwargs.get("course_id")
+    course_key = CourseKey.from_string(course_id)
+    course_block = modulestore().get_course(course_key)
+    enable_in_course = course_block.other_course_settings.get("ENABLE_TURNITIN_SUBMISSION", False)
+
+    if enable_in_course:
+        call_ora_submission_created_task(submission)
+
+
+def call_ora_submission_created_task(submission):
     ora_submission_created_task.delay(
         submission.uuid,
         submission.anonymous_user_id,

--- a/platform_plugin_turnitin/handlers.py
+++ b/platform_plugin_turnitin/handlers.py
@@ -1,42 +1,26 @@
 """Event handlers for the Turnitin plugin."""
 
 from django.conf import settings
-from opaque_keys.edx.keys import UsageKey
 
-from platform_plugin_turnitin.edxapp_wrapper.modulestore import modulestore
 from platform_plugin_turnitin.tasks import ora_submission_created_task
+from platform_plugin_turnitin.utils import enabled_in_course
 
 
 def ora_submission_created(submission, **kwargs):
     """
     Handle the ORA_SUBMISSION_CREATED event.
 
-    Args:
-        submission (ORASubmissionData): The ORA submission data.
-    """
-    if settings.ENABLE_TURNITIN_SUBMISSION:
-        call_ora_submission_created_task(submission)
-        return
-
-    course_key = UsageKey.from_string(submission.location).course_key
-    course_block = modulestore().get_course(course_key)
-    enable_in_course = course_block.other_course_settings.get("ENABLE_TURNITIN_SUBMISSION", False)
-
-    if enable_in_course:
-        call_ora_submission_created_task(submission)
-
-
-def call_ora_submission_created_task(submission) -> None:
-    """
-    Call the ORA submission created task.
+    If the Turnitin feature is enabled globally or in the course, create a new task to
+    send the ORA submission data to Turnitin.
 
     Args:
         submission (ORASubmissionData): The ORA submission data.
     """
-    ora_submission_created_task.delay(
-        submission.uuid,
-        submission.anonymous_user_id,
-        submission.answer.parts,
-        submission.answer.file_names,
-        submission.answer.file_urls,
-    )
+    if settings.ENABLE_TURNITIN_SUBMISSION or enabled_in_course(submission.location):
+        ora_submission_created_task.delay(
+            submission.uuid,
+            submission.anonymous_user_id,
+            submission.answer.parts,
+            submission.answer.file_names,
+            submission.answer.file_urls,
+        )

--- a/platform_plugin_turnitin/settings/common.py
+++ b/platform_plugin_turnitin/settings/common.py
@@ -37,7 +37,7 @@ def plugin_settings(settings):
     Set of plugin settings used by the Open Edx platform.
     More info: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
     """
-
+    settings.ENABLE_TURNITIN_SUBMISSION = False
     # Configuration variables
     settings.TURNITIN_TII_API_URL = None
     settings.TURNITIN_TCA_INTEGRATION_FAMILY = None
@@ -73,14 +73,17 @@ def plugin_settings(settings):
             "exclude_submitted_works": False,
         },
     }
+    # Backend settings
     settings.TURNITIN_API_TIMEOUT = 30
     settings.PLATFORM_PLUGIN_TURNITIN_AUTHENTICATION_BACKEND = (
         "platform_plugin_turnitin.edxapp_wrapper.backends.authentication_q_v1"
     )
-    settings.PLATFORM_PLUGIN_TURNITIN_STUDENT_BACKEND = (
-        "platform_plugin_turnitin.edxapp_wrapper.backends.student_q_v1"
-    )
+    settings.PLATFORM_PLUGIN_TURNITIN_STUDENT_BACKEND = "platform_plugin_turnitin.edxapp_wrapper.backends.student_q_v1"
     settings.PLATFORM_PLUGIN_TURNITIN_COURSE_OVERVIEWS_BACKEND = (
         "platform_plugin_turnitin.edxapp_wrapper.backends.course_overviews_q_v1"
     )
+    settings.PLATFORM_PLUGIN_TURNITIN_MODULESTORE_BACKEND = (
+        "platform_plugin_turnitin.edxapp_wrapper.backends.modulestore_q_v1"
+    )
+    # Template settings
     settings.MAKO_TEMPLATE_DIRS_BASE.append(ROOT_DIRECTORY / "templates/turnitin")

--- a/platform_plugin_turnitin/settings/production.py
+++ b/platform_plugin_turnitin/settings/production.py
@@ -10,6 +10,9 @@ def plugin_settings(settings):
     Set of plugin settings used by the Open Edx platform.
     More info: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
     """
+    settings.ENABLE_TURNITIN_SUBMISSION = getattr(settings, "ENV_TOKENS", {}).get(
+        "ENABLE_TURNITIN_SUBMISSION", settings.ENABLE_TURNITIN_SUBMISSION
+    )
     settings.TURNITIN_TII_API_URL = getattr(settings, "ENV_TOKENS", {}).get(
         "TURNITIN_TII_API_URL", settings.TURNITIN_TII_API_URL
     )
@@ -26,9 +29,7 @@ def plugin_settings(settings):
         "TURNITIN_TCA_API_KEY", settings.TURNITIN_TCA_API_KEY
     )
 
-    settings.TURNITIN_SIMILARITY_REPORT_PAYLOAD = getattr(
-        settings, "ENV_TOKENS", {}
-    ).get(
+    settings.TURNITIN_SIMILARITY_REPORT_PAYLOAD = getattr(settings, "ENV_TOKENS", {}).get(
         "TURNITIN_SIMILARITY_REPORT_PAYLOAD",
         settings.TURNITIN_SIMILARITY_REPORT_PAYLOAD,
     )
@@ -36,22 +37,20 @@ def plugin_settings(settings):
     settings.TURNITIN_API_TIMEOUT = getattr(settings, "ENV_TOKENS", {}).get(
         "TURNITIN_API_TIMEOUT", settings.TURNITIN_API_TIMEOUT
     )
-    settings.PLATFORM_PLUGIN_TURNITIN_AUTHENTICATION_BACKEND = getattr(
-        settings, "ENV_TOKENS", {}
-    ).get(
+    settings.PLATFORM_PLUGIN_TURNITIN_AUTHENTICATION_BACKEND = getattr(settings, "ENV_TOKENS", {}).get(
         "PLATFORM_PLUGIN_TURNITIN_AUTHENTICATION_BACKEND",
         settings.PLATFORM_PLUGIN_TURNITIN_AUTHENTICATION_BACKEND,
     )
-    settings.PLATFORM_PLUGIN_TURNITIN_STUDENT_BACKEND = getattr(
-        settings, "ENV_TOKENS", {}
-    ).get(
+    settings.PLATFORM_PLUGIN_TURNITIN_STUDENT_BACKEND = getattr(settings, "ENV_TOKENS", {}).get(
         "PLATFORM_PLUGIN_TURNITIN_STUDENT_BACKEND",
         settings.PLATFORM_PLUGIN_TURNITIN_STUDENT_BACKEND,
     )
-    settings.PLATFORM_PLUGIN_TURNITIN_COURSE_OVERVIEWS_BACKEND = getattr(
-        settings, "ENV_TOKENS", {}
-    ).get(
+    settings.PLATFORM_PLUGIN_TURNITIN_COURSE_OVERVIEWS_BACKEND = getattr(settings, "ENV_TOKENS", {}).get(
         "PLATFORM_PLUGIN_TURNITIN_COURSE_OVERVIEWS_BACKEND",
         settings.PLATFORM_PLUGIN_TURNITIN_COURSE_OVERVIEWS_BACKEND,
+    )
+    settings.PLATFORM_PLUGIN_TURNITIN_MODULESTORE_BACKEND = getattr(settings, "ENV_TOKENS", {}).get(
+        "PLATFORM_PLUGIN_TURNITIN_MODULESTORE_BACKEND",
+        settings.PLATFORM_PLUGIN_TURNITIN_MODULESTORE_BACKEND,
     )
     settings.MAKO_TEMPLATE_DIRS_BASE.append(ROOT_DIRECTORY / "templates/turnitin")

--- a/platform_plugin_turnitin/templates/turnitin/oa_response.html
+++ b/platform_plugin_turnitin/templates/turnitin/oa_response.html
@@ -338,6 +338,7 @@
                         <button type="submit" class="action action--submit step--response__submit"
                                 text_response="{{text_response}}"
                                 file_upload_response="{{file_upload_response}}"
+                                allow_learner_resubmissions="{{allow_learner_resubmissions}}"
                                 >
                             {% trans "Submit your response and move to the next step" %}
                         </button>

--- a/platform_plugin_turnitin/tests/test_filters.py
+++ b/platform_plugin_turnitin/tests/test_filters.py
@@ -1,7 +1,10 @@
 """This module contains tests for the filters module."""
 
 from unittest import TestCase
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
+
+from django.test.utils import override_settings
+from opaque_keys.edx.keys import UsageKey
 
 from platform_plugin_turnitin.extensions.filters import ORASubmissionViewTurnitinWarning
 
@@ -10,19 +13,62 @@ class TestORASubmissionViewTurnitinWarning(TestCase):
     """Tests for the ORASubmissionViewTurnitinWarning class."""
 
     def setUp(self) -> None:
-        self.pipeline_step = ORASubmissionViewTurnitinWarning(
-            filter_type=Mock(), running_pipeline=Mock()
-        )
-        self.context = {"key": "value"}
+        self.pipeline_step = ORASubmissionViewTurnitinWarning(filter_type=Mock(), running_pipeline=Mock())
+        self.context = {"key": "value", "xblock_id": "test_xblock_id"}
         self.template_name = "template_name"
         self.new_template_name = "turnitin/oa_response.html"
 
-    def test_run_filter(self):
+    @patch("platform_plugin_turnitin.extensions.filters.modulestore")
+    @patch.object(UsageKey, "from_string")
+    def test_run_filter_turnitin_submission_disabled(self, mock_from_string: Mock, mock_modulestore: Mock):
         """
-        Test that the `run_filter` method returns a dictionary with the context and the new template name.
+        Test `run_filter` method when Turnitin submission is disabled.
+
+        Expected result: The dictionary contains the same context and template name.
+        """
+        mock_from_string.return_value.course_key = "test_course_key"
+        mock_modulestore.return_value.get_course.return_value = Mock(
+            other_course_settings={"ENABLE_TURNITIN_SUBMISSION": False},
+        )
+
+        result = self.pipeline_step.run_filter(self.context, self.template_name)
+
+        self.assertEqual(result["context"], self.context)
+        self.assertEqual(result["template_name"], self.template_name)
+
+    @patch("platform_plugin_turnitin.extensions.filters.modulestore")
+    @patch.object(UsageKey, "from_string")
+    @override_settings(ENABLE_TURNITIN_SUBMISSION=True)
+    def test_run_filter_turnitin_submission_enabled_by_global_setting(
+        self, mock_from_string: Mock, mock_modulestore: Mock
+    ):
+        """
+        Test `run_filter` method when Turnitin submission is enabled by the global setting.
 
         Expected result: The dictionary contains the context and the new template name.
         """
+        result = self.pipeline_step.run_filter(self.context, self.template_name)
+
+        self.assertEqual(result["context"], self.context)
+        self.assertEqual(result["template_name"], self.new_template_name)
+        mock_from_string.assert_not_called()
+        mock_modulestore.assert_not_called()
+
+    @patch("platform_plugin_turnitin.extensions.filters.modulestore")
+    @patch.object(UsageKey, "from_string")
+    def test_run_filter_turnitin_submission_enabled_by_course_setting(
+        self, mock_from_string: Mock, mock_modulestore: Mock
+    ):
+        """
+        Test `run_filter` method when Turnitin submission is enabled by the course setting.
+
+        Expected result: The dictionary contains the context and the new template name.
+        """
+        mock_from_string.return_value.course_key = "test_course_key"
+        mock_modulestore.return_value.get_course.return_value = Mock(
+            other_course_settings={"ENABLE_TURNITIN_SUBMISSION": True},
+        )
+
         result = self.pipeline_step.run_filter(self.context, self.template_name)
 
         self.assertEqual(result["context"], self.context)

--- a/platform_plugin_turnitin/tests/test_filters.py
+++ b/platform_plugin_turnitin/tests/test_filters.py
@@ -4,7 +4,6 @@ from unittest import TestCase
 from unittest.mock import Mock, patch
 
 from django.test.utils import override_settings
-from opaque_keys.edx.keys import UsageKey
 
 from platform_plugin_turnitin.extensions.filters import ORASubmissionViewTurnitinWarning
 
@@ -18,30 +17,23 @@ class TestORASubmissionViewTurnitinWarning(TestCase):
         self.template_name = "template_name"
         self.new_template_name = "turnitin/oa_response.html"
 
-    @patch("platform_plugin_turnitin.extensions.filters.modulestore")
-    @patch.object(UsageKey, "from_string")
-    def test_run_filter_turnitin_submission_disabled(self, mock_from_string: Mock, mock_modulestore: Mock):
+    @patch("platform_plugin_turnitin.extensions.filters.enabled_in_course")
+    def test_run_filter_turnitin_submission_disabled(self, mock_enabled_in_course: Mock):
         """
         Test `run_filter` method when Turnitin submission is disabled.
 
         Expected result: The dictionary contains the same context and template name.
         """
-        mock_from_string.return_value.course_key = "test_course_key"
-        mock_modulestore.return_value.get_course.return_value = Mock(
-            other_course_settings={"ENABLE_TURNITIN_SUBMISSION": False},
-        )
+        mock_enabled_in_course.return_value = False
 
         result = self.pipeline_step.run_filter(self.context, self.template_name)
 
         self.assertEqual(result["context"], self.context)
         self.assertEqual(result["template_name"], self.template_name)
 
-    @patch("platform_plugin_turnitin.extensions.filters.modulestore")
-    @patch.object(UsageKey, "from_string")
+    @patch("platform_plugin_turnitin.extensions.filters.enabled_in_course")
     @override_settings(ENABLE_TURNITIN_SUBMISSION=True)
-    def test_run_filter_turnitin_submission_enabled_by_global_setting(
-        self, mock_from_string: Mock, mock_modulestore: Mock
-    ):
+    def test_run_filter_turnitin_submission_enabled_by_global_setting(self, mock_enabled_in_course: Mock):
         """
         Test `run_filter` method when Turnitin submission is enabled by the global setting.
 
@@ -51,23 +43,16 @@ class TestORASubmissionViewTurnitinWarning(TestCase):
 
         self.assertEqual(result["context"], self.context)
         self.assertEqual(result["template_name"], self.new_template_name)
-        mock_from_string.assert_not_called()
-        mock_modulestore.assert_not_called()
+        mock_enabled_in_course.assert_not_called()
 
-    @patch("platform_plugin_turnitin.extensions.filters.modulestore")
-    @patch.object(UsageKey, "from_string")
-    def test_run_filter_turnitin_submission_enabled_by_course_setting(
-        self, mock_from_string: Mock, mock_modulestore: Mock
-    ):
+    @patch("platform_plugin_turnitin.extensions.filters.enabled_in_course")
+    def test_run_filter_turnitin_submission_enabled_by_course_setting(self, mock_enabled_in_course: Mock):
         """
         Test `run_filter` method when Turnitin submission is enabled by the course setting.
 
         Expected result: The dictionary contains the context and the new template name.
         """
-        mock_from_string.return_value.course_key = "test_course_key"
-        mock_modulestore.return_value.get_course.return_value = Mock(
-            other_course_settings={"ENABLE_TURNITIN_SUBMISSION": True},
-        )
+        mock_enabled_in_course.return_value = True
 
         result = self.pipeline_step.run_filter(self.context, self.template_name)
 

--- a/platform_plugin_turnitin/tests/test_handlers.py
+++ b/platform_plugin_turnitin/tests/test_handlers.py
@@ -12,44 +12,49 @@ class TestHandlers(TestCase):
     """Tests for the handlers module."""
 
     def setUp(self) -> None:
-        self.submission = Mock(location="test_block_id")
-
-    @patch("platform_plugin_turnitin.handlers.call_ora_submission_created_task")
-    @patch("platform_plugin_turnitin.handlers.modulestore")
-    @patch("platform_plugin_turnitin.handlers.UsageKey")
-    def test_ora_submission_created_all_disabled(
-        self, mock_usage_key: Mock, mock_modulestore: Mock, mock_call_task: Mock
-    ):
-        """Test `ora_submission_created` when Turnitin submission is disabled globally and for the course."""
-        mock_usage_key.from_string.return_value.course_key = "course_key"
-        mock_modulestore.return_value.get_course.return_value = Mock(
-            other_course_settings={"ENABLE_TURNITIN_SUBMISSION": False},
+        self.submission = Mock(
+            uuid="submission_uuid",
+            location="block_id",
+            anonymous_user_id="user_id",
+            answer=Mock(parts=[], file_names=[], file_urls=[]),
         )
+
+    @patch("platform_plugin_turnitin.handlers.ora_submission_created_task.delay")
+    @patch("platform_plugin_turnitin.handlers.enabled_in_course")
+    def test_ora_submission_created_all_disabled(self, mock_enabled_in_course: Mock, mock_call_task: Mock):
+        """Test `ora_submission_created` when Turnitin submission is disabled globally and for the course."""
+        mock_enabled_in_course.return_value = False
 
         ora_submission_created(self.submission)
 
         mock_call_task.assert_not_called()
 
     @override_settings(ENABLE_TURNITIN_SUBMISSION=True)
-    @patch("platform_plugin_turnitin.handlers.call_ora_submission_created_task")
+    @patch("platform_plugin_turnitin.handlers.ora_submission_created_task.delay")
     def test_ora_submission_created_global_enabled(self, mock_call_task: Mock):
         """Test `ora_submission_created` when Turnitin submission is enabled globally."""
         ora_submission_created(self.submission)
 
-        mock_call_task.assert_called_once_with(self.submission)
-
-    @patch("platform_plugin_turnitin.handlers.call_ora_submission_created_task")
-    @patch("platform_plugin_turnitin.handlers.modulestore")
-    @patch("platform_plugin_turnitin.handlers.UsageKey")
-    def test_ora_submission_created_course_enabled(
-        self, mock_usage_key: Mock, mock_modulestore: Mock, mock_call_task: Mock
-    ):
-        """Test `ora_submission_created` when Turnitin submission is enabled for the course."""
-        mock_usage_key.from_string.return_value.course_key = "course_key"
-        mock_modulestore.return_value.get_course.return_value = Mock(
-            other_course_settings={"ENABLE_TURNITIN_SUBMISSION": True},
+        mock_call_task.assert_called_once_with(
+            self.submission.uuid,
+            self.submission.anonymous_user_id,
+            self.submission.answer.parts,
+            self.submission.answer.file_names,
+            self.submission.answer.file_urls,
         )
+
+    @patch("platform_plugin_turnitin.handlers.ora_submission_created_task.delay")
+    @patch("platform_plugin_turnitin.handlers.enabled_in_course")
+    def test_ora_submission_created_course_enabled(self, mock_enabled_in_course: Mock, mock_call_task: Mock):
+        """Test `ora_submission_created` when Turnitin submission is enabled for the course."""
+        mock_enabled_in_course.return_value = True
 
         ora_submission_created(self.submission)
 
-        mock_call_task.assert_called_once_with(self.submission)
+        mock_call_task.assert_called_once_with(
+            self.submission.uuid,
+            self.submission.anonymous_user_id,
+            self.submission.answer.parts,
+            self.submission.answer.file_names,
+            self.submission.answer.file_urls,
+        )

--- a/platform_plugin_turnitin/tests/test_handlers.py
+++ b/platform_plugin_turnitin/tests/test_handlers.py
@@ -1,0 +1,55 @@
+"""Tests for the handlers module."""
+
+from unittest.mock import Mock, patch
+
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from platform_plugin_turnitin.handlers import ora_submission_created
+
+
+class TestHandlers(TestCase):
+    """Tests for the handlers module."""
+
+    def setUp(self) -> None:
+        self.submission = Mock(location="test_block_id")
+
+    @patch("platform_plugin_turnitin.handlers.call_ora_submission_created_task")
+    @patch("platform_plugin_turnitin.handlers.modulestore")
+    @patch("platform_plugin_turnitin.handlers.UsageKey")
+    def test_ora_submission_created_all_disabled(
+        self, mock_usage_key: Mock, mock_modulestore: Mock, mock_call_task: Mock
+    ):
+        """Test `ora_submission_created` when Turnitin submission is disabled globally and for the course."""
+        mock_usage_key.from_string.return_value.course_key = "course_key"
+        mock_modulestore.return_value.get_course.return_value = Mock(
+            other_course_settings={"ENABLE_TURNITIN_SUBMISSION": False},
+        )
+
+        ora_submission_created(self.submission)
+
+        mock_call_task.assert_not_called()
+
+    @override_settings(ENABLE_TURNITIN_SUBMISSION=True)
+    @patch("platform_plugin_turnitin.handlers.call_ora_submission_created_task")
+    def test_ora_submission_created_global_enabled(self, mock_call_task: Mock):
+        """Test `ora_submission_created` when Turnitin submission is enabled globally."""
+        ora_submission_created(self.submission)
+
+        mock_call_task.assert_called_once_with(self.submission)
+
+    @patch("platform_plugin_turnitin.handlers.call_ora_submission_created_task")
+    @patch("platform_plugin_turnitin.handlers.modulestore")
+    @patch("platform_plugin_turnitin.handlers.UsageKey")
+    def test_ora_submission_created_course_enabled(
+        self, mock_usage_key: Mock, mock_modulestore: Mock, mock_call_task: Mock
+    ):
+        """Test `ora_submission_created` when Turnitin submission is enabled for the course."""
+        mock_usage_key.from_string.return_value.course_key = "course_key"
+        mock_modulestore.return_value.get_course.return_value = Mock(
+            other_course_settings={"ENABLE_TURNITIN_SUBMISSION": True},
+        )
+
+        ora_submission_created(self.submission)
+
+        mock_call_task.assert_called_once_with(self.submission)

--- a/platform_plugin_turnitin/utils.py
+++ b/platform_plugin_turnitin/utils.py
@@ -1,6 +1,6 @@
 """Utility functions for the Turnitin platform plugin."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from opaque_keys.edx.keys import UsageKey
 
@@ -18,7 +18,7 @@ def get_current_datetime() -> str:
     Returns:
         str: The current datetime in ISO 8601 format.
     """
-    return datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def enabled_in_course(block_id: str) -> bool:

--- a/platform_plugin_turnitin/utils.py
+++ b/platform_plugin_turnitin/utils.py
@@ -2,6 +2,10 @@
 
 from datetime import datetime
 
+from opaque_keys.edx.keys import UsageKey
+
+from platform_plugin_turnitin.edxapp_wrapper.modulestore import modulestore
+
 
 def get_current_datetime() -> str:
     """
@@ -15,3 +19,18 @@ def get_current_datetime() -> str:
         str: The current datetime in ISO 8601 format.
     """
     return datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def enabled_in_course(block_id: str) -> bool:
+    """
+    Check if Turnitin feature is enabled in the course.
+
+    Args:
+        block_id (str): The block ID.
+
+    Returns:
+        bool: True if Turnitin feature is enabled in the course, False otherwise.
+    """
+    course_key = UsageKey.from_string(block_id).course_key
+    course_block = modulestore().get_course(course_key)
+    return course_block.other_course_settings.get("ENABLE_TURNITIN_SUBMISSION", False)

--- a/test_settings.py
+++ b/test_settings.py
@@ -63,13 +63,13 @@ TEMPLATES = [
 ]
 
 # Plugin settings
+ENABLE_TURNITIN_SUBMISSION = False
 PLATFORM_PLUGIN_TURNITIN_AUTHENTICATION_BACKEND = (
     "platform_plugin_turnitin.edxapp_wrapper.backends.authentication_q_v1_test"
 )
-PLATFORM_PLUGIN_TURNITIN_STUDENT_BACKEND = (
-    "platform_plugin_turnitin.edxapp_wrapper.backends.student_q_v1_test"
-)
+PLATFORM_PLUGIN_TURNITIN_STUDENT_BACKEND = "platform_plugin_turnitin.edxapp_wrapper.backends.student_q_v1_test"
 PLATFORM_PLUGIN_TURNITIN_COURSE_OVERVIEWS_BACKEND = (
     "platform_plugin_turnitin.edxapp_wrapper.backends.course_overviews_q_v1_test"
 )
+PLATFORM_PLUGIN_TURNITIN_MODULESTORE_BACKEND = "platform_plugin_turnitin.edxapp_wrapper.backends.modulestore_q_v1_test"
 TURNITIN_SIMILARITY_REPORT_PAYLOAD = {"test_key": "test_value"}


### PR DESCRIPTION
### Description
This PR adds the possibility to activate the Turnitin functionality using two types of configuration:
- Globally using a **Django settings** (`ENABLE_TURNITIN_SUBMISSION`)
- At course level using **other_course_settings** (`ENABLE_TURNITIN_SUBMISSION`)

### How to Test
1. Install this plugin with the changes in this branch in your environment.
2. Install `edx-ora2`, `openedx-events`, and `openedx-filters` with the latest versions. 
3. In a unit of the course create a new ora assessment, maybe **Staff Assessment Only**.
4. In the settings of the component > **File Uploads Response = Required** and in **File Types = pdf,doc,docx**
5. By default, the functionality is disabled, therefore, no warning message will be displayed, nor will the files be sent to Turnitin.
6. If activated using either of the two settings mentioned above, a warning message will be displayed, and the files will be sent to Turnitin.
